### PR TITLE
Remove cssify as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,6 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "can-symbol",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "Done",
     "JS"
@@ -49,9 +39,6 @@
       "donejs-cli",
       "steal-tools"
     ]
-  },
-  "dependencies": {
-    "cssify": "^0.6.0"
   },
   "devDependencies": {
     "jshint": "^2.9.1",


### PR DESCRIPTION
It’s not used and it breaks Browserify usage.