### PR TITLE
Add @package to the docs

### DIFF
--- a/can-symbol.md
+++ b/can-symbol.md
@@ -1,5 +1,6 @@
 @page can-symbol
 @parent can-infrastructure
+@package ./package.json
 @group can-symbol/symbols/type Type Symbols
 @group can-symbol/symbols/shape Shape Symbols
 @group can-symbol/symbols/get-set Get/Set Symbols


### PR DESCRIPTION
This fixes an issue with the GitHub star and npm download buttons not appearing in the rendered canjs.com docs.