### PR TITLE
Add getWhatIChange and getChangesDependencyRecord symbols

### DIFF
--- a/can-symbol.js
+++ b/can-symbol.js
@@ -103,12 +103,14 @@ if(typeof Symbol !== "undefined" && typeof Symbol.for === "function") {
 	"offKeyValue",
 	"getKeyDependencies",
 	"getValueDependencies",
+	"getWhatIChange",
+	"getChangesDependencyRecord",
 	"keyHasDependencies",
 	"valueHasDependencies",
 	"onKeys",
 	"onKeysAdded",
 	"onKeysRemoved"
-	].forEach(function(name){
+].forEach(function(name){
 	CanSymbol.for("can."+name);
 });
 


### PR DESCRIPTION
@justinbmeyer I ended up using `can.getChangesDependecyRecord` instead of `can.changes`, I'm not a fan of either name. What do you think? 

- [ ] Document symbols before merge